### PR TITLE
peerDependencies and dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,18 +27,20 @@
   "bugs": {
     "url": "https://github.com/packetloop/connect-dynamodb-session/issues"
   },
+  "dependencies": {
+    "aws-sdk": "2.3.6",
+    "bluebird": "3.3.5"
+  },
   "peerDependencies": {
     "aws-sdk": "2",
     "bluebird": "3"
   },
   "devDependencies": {
-    "aws-sdk": "2.3.6",
     "babel-cli": "6.7.7",
     "babel-core": "6.7.7",
     "babel-istanbul": "0.8.0",
     "babel-preset-es2015": "6.6.0",
     "blue-tape": "0.2.0",
-    "bluebird": "3.3.5",
     "codacy-coverage": "1.1.3",
     "eslint": "2.8.0",
     "eslint-config-airbnb": "8.0.0",


### PR DESCRIPTION
I think it could be a good idea to add the peerDependencies among the dependencies. In that way, if you are not using one of the peerDependencies in production mode, they will be installed.
