### PR TITLE
use 'add-module-exports' plugin for babel to have the expected nodejs behavior with export default

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,8 @@
 {
   "presets": [
     "es2015"
+  ],
+  "plugins": [
+    "add-module-exports"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-cli": "6.7.7",
     "babel-core": "6.7.7",
     "babel-istanbul": "0.8.0",
+    "babel-plugin-add-module-exports": "0.2.1",
     "babel-preset-es2015": "6.6.0",
     "blue-tape": "0.2.0",
     "bluebird": "3.3.5",


### PR DESCRIPTION
use 'add-module-exports' plugin for babel to have the expected nodejs behavior with export default

close #14 